### PR TITLE
 Allow st.feedback to have a default initial value (#9469) -> #9658

### DIFF
--- a/e2e_playwright/st_feedback.py
+++ b/e2e_playwright/st_feedback.py
@@ -16,6 +16,11 @@ import time
 
 import streamlit as st
 
+if st.checkbox("Set default value", value=False):
+    st.session_state.default_feedback = 2
+else:
+    st.session_state.default_feedback = None
+
 with st.container(key="thumbs_container"):
     st.feedback()
     st.session_state.thumbs_feedback_disabled = 1
@@ -32,15 +37,11 @@ with st.container(key="faces_container"):
         ),
     )
     st.session_state.faces_feedback_disabled = 3
-    st.feedback(
-        "faces",
-        key="faces_feedback_disabled",
-        disabled=True,
-    )
+    st.feedback("faces", key="faces_feedback_disabled", disabled=True)
     st.feedback("faces", key="faces_feedback_hover_test")
 
 with st.container(key="stars_container"):
-    sentiment = st.feedback("stars")
+    sentiment = st.feedback("stars", default=st.session_state.default_feedback)
     st.write(f"Star sentiment: {sentiment}")
     st.session_state.star_feedback_disabled = 3
     sentiment = st.feedback("stars", disabled=True, key="star_feedback_disabled")

--- a/e2e_playwright/st_feedback_test.py
+++ b/e2e_playwright/st_feedback_test.py
@@ -22,7 +22,9 @@ from e2e_playwright.conftest import ImageCompareFunction, wait_for_app_run
 from e2e_playwright.shared.app_utils import (
     check_top_level_class,
     click_button,
+    click_checkbox,
     click_form_button,
+    expect_markdown,
     get_element_by_key,
     get_markdown,
 )
@@ -135,6 +137,17 @@ def test_feedback_buttons_are_disabled(app: Page):
     # the feedback value was set to 3 via session state
     text = get_markdown(app, "feedback-disabled: 3")
     expect(text).to_be_attached()
+
+
+def test_pass_default_selections(app: Page):
+    """Test that passed defaults are rendered correctly."""
+    expect_markdown(app, "Star sentiment: None")
+
+    click_checkbox(app, "Set default value")
+    expect_markdown(app, "Star sentiment: 2")
+
+    click_checkbox(app, "Set default value")
+    expect_markdown(app, "Star sentiment: None")
 
 
 def test_feedback_works_in_forms(app: Page):

--- a/lib/streamlit/elements/widgets/button_group.py
+++ b/lib/streamlit/elements/widgets/button_group.py
@@ -276,6 +276,7 @@ class ButtonGroupMixin:
         options: Literal["thumbs"] = ...,
         *,
         key: Key | None = None,
+        default: int | None = None,
         disabled: bool = False,
         on_change: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
@@ -288,6 +289,7 @@ class ButtonGroupMixin:
         options: Literal["faces", "stars"] = ...,
         *,
         key: Key | None = None,
+        default: int | None = None,
         disabled: bool = False,
         on_change: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
@@ -300,6 +302,7 @@ class ButtonGroupMixin:
         options: Literal["thumbs", "faces", "stars"] = "thumbs",
         *,
         key: Key | None = None,
+        default: int | None = None,
         disabled: bool = False,
         on_change: WidgetCallback | None = None,
         args: WidgetArgs | None = None,
@@ -330,6 +333,11 @@ class ButtonGroupMixin:
             An optional string or integer to use as the unique key for the widget.
             If this is omitted, a key will be generated for the widget
             based on its content. No two widgets may have the same key.
+
+        default : int or None
+            An optional integer to be the default feedback value.
+            Must be a number between 0 and 1 for ``options="thumbs"``, and
+            between 0 and 4 for ``options="faces"`` and ``options="stars"``.
 
         disabled : bool
             An optional boolean that disables the feedback widget if set
@@ -407,7 +415,17 @@ class ButtonGroupMixin:
                 f"The argument passed was '{options}'."
             )
         transformed_options, options_indices = get_mapped_options(options)
-        serde = _SingleSelectSerde[int](options_indices)
+
+        if default is not None and (default < 0 or default >= len(transformed_options)):
+            raise StreamlitAPIException(
+                f"The default value in '{options}' must be a number between 0 and {len(transformed_options) - 1}."
+                f" The passed default value is {default}"
+            )
+
+        _default: list[int] | None = (
+            [options_indices[default]] if default is not None else None
+        )
+        serde = _SingleSelectSerde[int](options_indices, default_value=_default)
 
         selection_visualization = ButtonGroupProto.SelectionVisualization.ONLY_SELECTED
         if options == "stars":
@@ -417,7 +435,7 @@ class ButtonGroupMixin:
 
         sentiment = self._button_group(
             transformed_options,
-            default=None,
+            default=_default,
             key=key,
             selection_mode="single",
             disabled=disabled,

--- a/lib/tests/streamlit/elements/button_group_test.py
+++ b/lib/tests/streamlit/elements/button_group_test.py
@@ -374,6 +374,14 @@ class ButtonGroupCommandTests(DeltaGeneratorTestCase):
     @parameterized.expand(
         [
             (st.feedback, ("thumbs",)),
+            (
+                st.feedback,
+                ("thumbs",),
+                {"default": 1},
+                1,
+            ),
+            (st.feedback, ("stars",), {"default": 2}, 2),
+            (st.feedback, ("faces",), {"default": 3}, 3),
             (st.pills, ("label", ["a", "b", "c"])),
             (st.pills, ("label", ["a", "b", "c"]), {"default": "b"}, "b"),
             (


### PR DESCRIPTION
Recreated from original PR: https://github.com/streamlit/streamlit/pull/12578

## Describe your changes
Rebase with current develop w.r.t. [#9658](https://github.com/streamlit/streamlit/pull/9658/files)
All credits to @wjkim00

## GitHub Issue Link (if applicable)

Closes https://github.com/streamlit/streamlit/issues/9469

## Testing Plan

- Explanation of why no additional tests are needed
- Unit Tests (JS and/or Python)
- E2E Tests
- Any manual testing needed?

---

**Contribution License Agreement**

By submitting this pull request you agree that all ...